### PR TITLE
refactor(i18n): 改进国际化支持

### DIFF
--- a/examples/i18n.html
+++ b/examples/i18n.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>i18n - Layui</title>
+    <link href="../src/css/layui.css" rel="stylesheet" />
+    <style>
+      body {
+        transition: opacity 0.8s ease-in-out;
+        opacity: 0;
+      }
+    </style>
+  </head>
+  <body class="layui-padding-3">
+    <div id="root"></div>
+    <template id="template">
+      {{ const i18n = layui.i18n; }}
+      <div class="layui-form">
+        <div class="layui-inline">
+          <strong>{{= i18n.$t('custom.switchLanguage') }}: </strong>
+        </div>
+        <div class="layui-inline">
+          <select id="change-locale" lay-filter="change-locale">
+            <option value="zh-CN">简体中文</option>
+            <option value="en">English</option>
+            <option value="fr">Français</option>
+            <option value="zh-HK">繁體中文</option>
+          </select>
+        </div>
+      </div>
+      <br>
+      <fieldset class="layui-elem-field">
+        <legend>README</legend>
+        <div class="layui-field-box layui-text" id="tpl-test">
+          <p>{{= i18n.$t('custom.readme.description') }}</p>
+          <ul>
+            <li><strong>locale</strong>: <span style="color:red">{{= i18n.config.locale }}</span></li>
+            <li><strong>Date</strong>: {{= new Date().toLocaleDateString(i18n.config.locale) }}</li>
+            <li><strong>Hello</strong>: {{= i18n.$t('custom.readme.hello') }}</li>
+          </ul>
+        </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>code</legend>
+        <div class="layui-field-box">
+          <pre id="demo-code" class="layui-code" lay-options="{}">
+            <textarea>
+              code content
+            </textarea>
+          </pre>
+        </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>colorpicker</legend>
+        <div class="layui-field-box">
+          <div id="demo-colorpicker"></div>
+        </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>dropdown</legend>
+        <div class="layui-field-box">
+          <button id="demo-dropdown" class="layui-btn demo-dropdown-base">
+            <span>Dropdown</span>
+            <i class="layui-icon layui-icon-down layui-font-12"></i>
+          </button>
+        </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>flow</legend>
+        <div class="layui-field-box">
+          <div class="flow-demo" id="demo-flow"></div>
+        </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>form</legend>
+        <div class="layui-field-box">
+          <form class="layui-form" action="">
+            <div class="layui-form-item">
+              <label class="layui-form-label">{{= i18n.$t('custom.form.required') }}</label>
+              <div class="layui-input-block">
+                <input type="text" name="username" lay-verify="required" lay-vertype="alert" placeholder="{{= i18n.$t('custom.form.placeholder') }}" autocomplete="off" class="layui-input">
+              </div>
+            </div>
+            <div class="layui-form-item">
+              <div class="layui-inline">
+                <label class="layui-form-label">{{= i18n.$t('custom.form.phone') }}</label>
+                <div class="layui-input-inline layui-input-wrap">
+                  <input type="tel" name="phone" lay-verify="phone" autocomplete="off" value="123456" lay-affix="clear"
+                    class="layui-input demo-phone">
+                </div>
+              </div>
+            </div>
+            <div class="layui-form-item">
+              <div class="layui-inline">
+                <label class="layui-form-label">{{= i18n.$t('custom.form.email') }}</label>
+                <div class="layui-input-inline">
+                  <input type="text" name="email" value="123.com" lay-verify="email" autocomplete="off"
+                    class="layui-input">
+                </div>
+              </div>
+              <div class="layui-inline">
+                <label class="layui-form-label">{{= i18n.$t('custom.form.date') }}</label>
+                <div class="layui-input-inline layui-input-wrap">
+                  <div class="layui-input-prefix">
+                    <i class="layui-icon layui-icon-date"></i>
+                  </div>
+                  <input type="text" name="date" value="2077" id="date" lay-verify="date" placeholder="yyyy-MM-dd"
+                    autocomplete="off" class="layui-input">
+                </div>
+              </div>
+            </div>
+            <div class="layui-form-item">
+              <label class="layui-form-label">{{= i18n.$t('custom.form.select') }}</label>
+              <div class="layui-input-block">
+                <select name="interest" lay-filter="aihao" lay-search>
+                  <option value=""></option>
+                  <option value="0">AAA</option>
+                  <option value="1" selected>BBB</option>
+                  <option value="2">CCC</option>
+                  <option value="3">DDD</option>
+                  <option value="4">EEE</option>
+                </select>
+              </div>
+            </div>
+            <div class="layui-form-item">
+              <div class="layui-input-block">
+                <button type="submit" class="layui-btn" lay-submit lay-filter="demo1">
+                  {{= i18n.$t('custom.form.submit') }}
+                </button>
+                <button type="reset" class="layui-btn layui-btn-primary">
+                  {{= i18n.$t('custom.form.reset') }}
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>laydate</legend>
+        <div class="layui-field-box">
+          <div class="layui-inline">
+            <input class="layui-input" id="demo-laydate" />
+          </div>
+        </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>layer</legend>
+        <div class="layui-field-box">
+          <button type="button" class="layui-btn layui-btn-primary" lay-on="alert">Alert</button>
+          <button type="button" class="layui-btn layui-btn-primary" lay-on="prompt">Prompt</button>
+          <button type="button" class="layui-btn layui-btn-primary" lay-on="photos">Photos</button>
+        </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>laypage</legend>
+        <div class="layui-field-box">
+          <div id="demo-laypage-all"></div>
+        </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>table</legend>
+        <div class="layui-field-box">
+          <table class="layui-hide" id="demo-table" lay-filter="test"></table>
+          </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>transfer</legend>
+        <div class="layui-field-box">
+          <div id="demo-transfer"></div>
+        </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>tree</legend>
+        <div class="layui-field-box">
+          <div id="demo-tree"></div>
+        </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>upload</legend>
+        <div class="layui-field-box">
+          <button type="button" class="layui-btn" id="demo-upload">
+            <i class="layui-icon layui-icon-upload"></i> Upload
+          </button>
+        </div>
+      </fieldset>
+      <fieldset class="layui-elem-field">
+        <legend>utils</legend>
+        <div class="layui-field-box">
+          <label>
+            timeAgo: <input id="demo-time-ago-picker" type="datetime-local" /> <span id="demo-time-ago-display"></span>
+          </label>
+          <br>
+          <label>
+            toDateString: <div id="demo-toDateString"></div>
+          </label>
+        </div>
+      </fieldset>
+    </template>
+
+    <script src="../src/layui.js"></script>
+    <script>
+    layui.use(async function () {
+      const {
+        $, colorpicker, dropdown, flow, form,
+        i18n, laydate, laypage, laytpl, layer,
+        table, transfer, tree, upload, util
+      } = layui;
+
+      // 演示异步加载组件语言包
+      const { default: en } = await import('./i18n/en.js');
+      const { default: fr } = await import('./i18n/fr.js');
+      const { default: zhHK } = await import('./i18n/zh-HK.js');
+
+      // 组件 i18n 配置
+      i18n.set({
+        locale: layui.data('layui-i18n-test').locale || 'zh-CN', // 指定语言
+        messages: {
+          en, // 扩展英语
+          fr, // 扩展法语
+          'zh-HK': zhHK, // 扩展繁体中文
+        },
+      });
+
+      // 业务 i18n 配置
+      i18n.set({
+        messages: {
+          'zh-CN': {
+            custom: {
+              switchLanguage: '切换语言',
+              readme: {
+                description: 'layui.i18n.$t 是私有方法（未文档化），此处仅用于演示',
+                hello: '你好',
+              },
+              form: {
+                required: '验证必填项',
+                phone: '验证手机号',
+                email: '验证邮箱',
+                date: '验证日期',
+                select: '选择框',
+                submit: '立即提交',
+                reset: '重置',
+                placeholder: '请输入'
+              }
+            }
+          },
+          'en': {
+            custom: {
+              switchLanguage: 'Switch Language',
+              readme: {
+                description: 'layui.i18n.$t is a private method (undocumented), used here for demonstration only.',
+                hello: 'Hello',
+              },
+              form: {
+                required: 'Required',
+                phone: 'Telephone',
+                email: 'Email',
+                date: 'Date',
+                select: 'Select',
+                submit: 'Submit',
+                reset: 'Reset',
+                placeholder: 'Please enter'
+              }
+            }
+          },
+          'fr': {
+            custom: {
+              switchLanguage: 'Changer la langue',
+              readme: {
+                description: 'layui.i18n.$t est une méthode privée (non documentée), utilisée ici uniquement à des fins de démonstration.',
+                hello: 'Bonjour',
+              },
+              form: {
+                required: 'Requis',
+                phone: 'Téléphone',
+                email: 'Email',
+                date: 'Date',
+                select: 'Sélection',
+                submit: 'Soumettre maintenant',
+                reset: 'Réinitialiser',
+                placeholder: 'Veuillez entrer'
+              }
+            }
+          },
+          'zh-HK': {
+            custom: {
+              switchLanguage: '切換語言',
+              readme: {
+                description: 'layui.i18n.$t 是私有方法（未文檔化），此處僅用於示範',
+                hello: '你好',
+              },
+              form: {
+                required: '驗證必填項',
+                phone: '驗證手機號',
+                email: '驗證郵箱',
+                date: '驗證日期',
+                select: '選擇框',
+                submit: '立即提交',
+                reset: '重置',
+                placeholder: '請輸入'
+              }
+            }
+          }
+        }
+      });
+
+      // 渲染页面模板
+      const template = $('#template').html();
+      const html = laytpl(template, { tagStyle: 'modern' }).render();
+      $('#root').html(html);
+
+
+      /**
+       * 组件示例
+       */
+
+      // code
+      layui.code({
+        elem: "#demo-code",
+        preview: true,
+        tools: ['copy', 'full', 'window'],
+        header: true,
+        lang: 'html',
+        langMarker: true,
+      });
+
+      // colorpicker
+      colorpicker.render({
+        elem: "#demo-colorpicker",
+      });
+
+      // dropdown
+      dropdown.render({
+        elem: "#demo-dropdown",
+      });
+
+      // flow
+      flow.load({
+        elem: '#demo-flow',
+        scrollElem: '#demo-flow',
+        done: function (page, next) {
+          // 模拟数据插入
+          setTimeout(function () {
+            var lis = [];
+            for (var i = 0; i < 3; i++) {
+              lis.push('<li>' + ((page - 1) * 3 + i + 1) + '</li>')
+            }
+            next(lis.join(''), page < 2);
+          }, 200);
+        }
+      });
+
+      // form
+      form.on('submit(demo1)', function (data) {
+        var field = data.field;
+        // 显示填写结果，仅作演示用
+        layer.alert(JSON.stringify(field));
+        return false;
+      });
+
+      //laydate
+      laydate.render({
+        elem: "#demo-laydate",
+        type: "datetime",
+        calendar: true
+      });
+
+      // layer
+      util.on({
+        alert: function () {
+          layer.alert("Hello world");
+        },
+        prompt: function () {
+          layer.prompt({ formType: 1, maxlength: 3 }, function (value, index) {
+            layer.close(index);
+          });
+        },
+        photos: function () {
+          layer.photos({
+            photos: {
+              "title": "Photos Demo",
+              "start": 0,
+              "data": [
+                {
+                  "alt": "layer",
+                  "pid": 1,
+                  "src": "https://unpkg.com/outeres@0.1.1/demo/layer.png",
+                },
+                {
+                  "alt": "error",
+                  "pid": 3,
+                  "src": "",
+                },
+                {
+                  "alt": "universe",
+                  "pid": 5,
+                  "src": "https://unpkg.com/outeres@0.1.1/demo/outer-space.jpg",
+                }
+              ]
+            }
+          });
+        }
+      })
+
+      // laypage
+      laypage.render({
+        elem: "demo-laypage-all",
+        count: 100,
+        layout: ["count", "prev", "page", "next", "limit", "refresh", "skip"],
+      });
+
+      // table
+      table.render({
+        elem: '#demo-table',
+        cols: [[{ field: 'test', title: '1', sort: true }, { field: 'test2', title: '2', sort: true }]],
+        data: new Array(0),
+        toolbar: 'default',
+        defaultToolbar: ['filter', 'exports', 'print'],
+        height: 'full',
+        page: true,
+        text: {
+          // none: 'none'
+        }
+      });
+
+      // transfer
+      transfer.render({
+        elem: '#demo-transfer',
+        data: [
+          { "value": "1", "title": "Item 1" },
+          { "value": "2", "title": "Item 2" },
+          { "value": "3", "title": "Item 3" },
+        ],
+        showSearch: true
+      });
+
+      // tree
+      tree.render({
+        elem: '#demo-tree',
+        //data: [],
+        data: [{ title: 'Item 1', id: 1, children: [{ title: 'Item 1-1', id: 2 }] }],
+        edit: ['add', 'update', 'del']
+      });
+
+      // upload
+      upload.render({
+        elem: '#demo-upload',
+        url: '', // 实际使用时改成您自己的上传接口即可。
+        multiple: true,
+        accept: 'file',
+        //exts: 'zip',
+        number: 1,
+        //size: 60,
+      });
+
+      // util
+      $('#demo-time-ago-picker').on('change', function(){
+        $('#demo-time-ago-display').html(
+          util.timeAgo(this.value)
+        );
+      })
+
+      $('#demo-toDateString').html(
+        util.toDateString('2023-01-01 11:35:25', 'yyyy-MM-dd HH:mm:ss A')
+        + '<br>'
+        + util.toDateString('2023-01-01 18:35:25', 'yyyy-MM-dd HH:mm:ss A')
+      )
+
+      // 演示：切换语言
+      $("#change-locale").val(i18n.config.locale);
+      form.render('select').on("select(change-locale)", function (elem) {
+        // 记录语言，并重载页面（推荐）
+        layui.data('layui-i18n-test', {
+          key: 'locale',
+          value: elem.value
+        });
+        window.location.reload();
+      });
+
+      $("body").css("opacity", 1);
+      layer.msg(layui.v);
+      console.log(i18n.config)
+    });
+    </script>
+  </body>
+</html>

--- a/examples/i18n/en.js
+++ b/examples/i18n/en.js
@@ -1,0 +1,155 @@
+/**
+ * English (en)
+ */
+
+// Common English internationalization message object
+export default {
+  code: {
+    copy: 'Copy Code',
+    copied: 'Copied',
+    copyError: 'Copy Failed',
+    maximize: 'Maximize',
+    restore: 'Restore',
+    preview: 'Preview in New Window'
+  },
+  colorpicker: {
+    clear: 'Clear',
+    confirm: 'OK'
+  },
+  dropdown: {
+    noData: 'No Data'
+  },
+  flow: {
+    loadMore: 'Load More',
+    noMore: 'No More Data'
+  },
+  form: {
+    select: {
+      noData: 'No Data',
+      noMatch: 'No Matching Data',
+      placeholder: 'Please Select'
+    },
+    validateMessages: {
+      required: 'This field is required',
+      phone: 'Invalid phone number format',
+      email: 'Invalid email format',
+      url: 'Invalid URL format',
+      number: 'Numbers only',
+      date: 'Invalid date format',
+      identity: 'Invalid ID number format'
+    },
+    verifyErrorPromptTitle: 'Notice'
+  },
+  layer: {
+    confirm: 'OK',
+    cancel: 'Cancel',
+    defaultTitle: 'Info',
+    prompt: {
+      InputLengthPrompt: 'Maximum {length} characters'
+    },
+    photos: {
+      noData: 'No Image',
+      tools: {
+        rotate: 'Rotate',
+        scaleX: 'Flip Horizontally',
+        zoomIn: 'Zoom In',
+        zoomOut: 'Zoom Out',
+        reset: 'Reset',
+        close: 'Close'
+      },
+      viewPicture: 'View Original',
+      urlError: {
+        prompt: 'Image URL is invalid<br>Continue to next one?',
+        confirm: 'Next',
+        cancel: 'Cancel'
+      }
+    }
+  },
+  laypage: {
+    prev: 'Prev',
+    next: 'Next',
+    first: 'First',
+    last: 'Last',
+    total: 'Total {total} items',
+    pagesize: 'items/page',
+    goto: 'Go to',
+    page: 'page',
+    confirm: 'Confirm'
+  },
+  table: {
+    sort: {
+      asc: 'Ascending',
+      desc: 'Descending'
+    },
+    noData: 'No Data',
+    tools: {
+      filter: {
+        title: 'Filter Columns'
+      },
+      export: {
+        title: 'Export',
+        noDataPrompt: 'No data in the table',
+        compatPrompt: 'Export is not supported in IE. Please use Chrome or another modern browser.',
+        csvText: 'Export CSV File'
+      },
+      print: {
+        title: 'Print',
+        noDataPrompt: 'No data in the table'
+      }
+    },
+    dataFormatError: 'Returned data is invalid. The correct success status code should be: "{statusName}": {statusCode}',
+    xhrError: 'Request Error: {msg}'
+  },
+  transfer: {
+    noData: 'No Data',
+    noMatch: 'No Match',
+    title: ['List One', 'List Two'],
+    searchPlaceholder: 'Search by Keyword'
+  },
+  tree: {
+    defaultNodeName: 'Unnamed',
+    noData: 'No Data',
+    deleteNodePrompt: 'Are you sure you want to delete the node "{name}"?'
+  },
+  upload: {
+    fileType: {
+      file: 'File',
+      image: 'Image',
+      video: 'Video',
+      audio: 'Audio'
+    },
+    validateMessages: {
+      fileExtensionError: 'Unsupported format in selected {fileType}',
+      filesOverLengthLimit: 'Maximum {length} files allowed at once',
+      currentFilesLength: 'You have selected {length} files',
+      fileOverSizeLimit: 'File size must not exceed {size}'
+    },
+    chooseText: '{length} files'
+  },
+  util: {
+    timeAgo: {
+      days: '{days} days ago',
+      hours: '{hours} hours ago',
+      minutes: '{minutes} minutes ago',
+      future: 'In the future',
+      justNow: 'Just now'
+    },
+    toDateString: {
+      meridiem: function (hours, minutes) {
+        var hm = hours * 100 + minutes;
+        if (hm < 600) {
+          return 'Midnight';
+        } else if (hm < 900) {
+          return 'Morning';
+        } else if (hm < 1100) {
+          return 'Forenoon';
+        } else if (hm < 1300) {
+          return 'Noon';
+        } else if (hm < 1800) {
+          return 'Afternoon';
+        }
+        return 'Evening';
+      }
+    }
+  }
+};

--- a/examples/i18n/fr.js
+++ b/examples/i18n/fr.js
@@ -1,0 +1,154 @@
+/**
+ * Français (fr)
+ */
+
+export default {
+  code: {
+    copy: 'Copier le code',
+    copied: 'Copié',
+    copyError: 'Échec de la copie',
+    maximize: 'Afficher en plein écran',
+    restore: 'Restaurer l’affichage',
+    preview: 'Aperçu dans une nouvelle fenêtre'
+  },
+  colorpicker: {
+    clear: 'Effacer',
+    confirm: 'OK'
+  },
+  dropdown: {
+    noData: 'Aucune donnée disponible'
+  },
+  flow: {
+    loadMore: 'Charger plus',
+    noMore: 'Plus de données'
+  },
+  form: {
+    select: {
+      noData: 'Aucune donnée disponible',
+      noMatch: 'Aucune correspondance',
+      placeholder: 'Veuillez sélectionner'
+    },
+    validateMessages: {
+      required: 'Ce champ est obligatoire',
+      phone: 'Numéro de téléphone invalide',
+      email: 'Adresse e-mail invalide',
+      url: 'URL invalide',
+      number: 'Uniquement des chiffres',
+      date: 'Format de date invalide',
+      identity: 'Numéro d’identification invalide'
+    },
+    verifyErrorPromptTitle: 'Avertissement'
+  },
+  layer: {
+    confirm: 'Confirmer',
+    cancel: 'Annuler',
+    defaultTitle: 'Information',
+    prompt: {
+      InputLengthPrompt: 'Maximum {length} caractères'
+    },
+    photos: {
+      noData: 'Aucune image',
+      tools: {
+        rotate: 'Faire pivoter',
+        scaleX: 'Inverser horizontalement',
+        zoomIn: 'Agrandir',
+        zoomOut: 'Réduire',
+        reset: 'Réinitialiser',
+        close: 'Fermer'
+      },
+      viewPicture: 'Voir l’image originale',
+      urlError: {
+        prompt: 'L’adresse de l’image est invalide<br>Continuer avec la suivante ?',
+        confirm: 'Suivante',
+        cancel: 'Annuler'
+      }
+    }
+  },
+  laypage: {
+    prev: 'Page précédente',
+    next: 'Page suivante',
+    first: 'Première',
+    last: 'Dernière',
+    total: 'Total {total} éléments',
+    pagesize: 'éléments/page',
+    goto: 'Aller à',
+    page: 'page',
+    confirm: 'Confirmer'
+  },
+  table: {
+    sort: {
+      asc: 'Croissant',
+      desc: 'Décroissant'
+    },
+    noData: 'Aucune donnée',
+    tools: {
+      filter: {
+        title: 'Filtrer les colonnes'
+      },
+      export: {
+        title: 'Exporter',
+        noDataPrompt: 'Aucune donnée à exporter',
+        compatPrompt: 'L’exportation n’est pas supportée par IE, veuillez utiliser Chrome ou un autre navigateur moderne',
+        csvText: 'Exporter au format CSV'
+      },
+      print: {
+        title: 'Imprimer',
+        noDataPrompt: 'Aucune donnée à imprimer'
+      }
+    },
+    dataFormatError: 'Les données retournées sont invalides. Le code de réussite attendu est : "{statusName}": {statusCode}',
+    xhrError: 'Erreur de requête : {msg}'
+  },
+  transfer: {
+    noData: 'Aucune donnée',
+    noMatch: 'Aucune correspondance',
+    title: ['Liste 1', 'Liste 2'],
+    searchPlaceholder: 'Recherche par mot-clé'
+  },
+  tree: {
+    defaultNodeName: 'Sans nom',
+    noData: 'Aucune donnée',
+    deleteNodePrompt: 'Confirmer la suppression du nœud "{name}" ?'
+  },
+  upload: {
+    fileType: {
+      file: 'Fichier',
+      image: 'Image',
+      video: 'Vidéo',
+      audio: 'Audio'
+    },
+    validateMessages: {
+      fileExtensionError: 'Le {fileType} sélectionné contient un format non supporté',
+      filesOverLengthLimit: 'Nombre maximum de fichiers : {length}',
+      currentFilesLength: 'Vous avez sélectionné {length} fichiers',
+      fileOverSizeLimit: 'La taille du fichier ne doit pas dépasser {size}'
+    },
+    chooseText: '{length} fichiers'
+  },
+  util: {
+    timeAgo: {
+      days: 'il y a {days} jours',
+      hours: 'il y a {hours} heures',
+      minutes: 'il y a {minutes} minutes',
+      future: 'Futur',
+      justNow: 'À l’instant'
+    },
+    toDateString: {
+      meridiem: function(hours, minutes){
+        var hm = hours * 100 + minutes;
+        if (hm < 600) {
+          return 'Tôt le matin';
+        } else if (hm < 900) {
+          return 'Matin';
+        } else if (hm < 1100) {
+          return 'Avant-midi';
+        } else if (hm < 1300) {
+          return 'Midi';
+        } else if (hm < 1800) {
+          return 'Après-midi';
+        }
+        return 'Soir';
+      }
+    }
+  }
+};

--- a/examples/i18n/zh-HK.js
+++ b/examples/i18n/zh-HK.js
@@ -1,0 +1,154 @@
+/**
+ * 繁體中文 (zh-HK)
+ */
+
+export default {
+  code: {
+    copy: '複製代碼',
+    copied: '已複製',
+    copyError: '複製失敗',
+    maximize: '最大化顯示',
+    restore: '還原顯示',
+    preview: '在新視窗預覽'
+  },
+  colorpicker: {
+    clear: '清除',
+    confirm: '確定'
+  },
+  dropdown: {
+    noData: '暫無資料'
+  },
+  flow: {
+    loadMore: '載入更多',
+    noMore: '沒有更多了'
+  },
+  form: {
+    select: {
+      noData: '暫無資料',
+      noMatch: '無匹配資料',
+      placeholder: '請選擇'
+    },
+    validateMessages: {
+      required: '必填項不能為空',
+      phone: '手機號碼格式不正確',
+      email: '電郵格式不正確',
+      url: '連結格式不正確',
+      number: '只能填寫數字',
+      date: '日期格式不正確',
+      identity: '身份證號碼格式不正確'
+    },
+    verifyErrorPromptTitle: '提示'
+  },
+  layer: {
+    confirm: '確定',
+    cancel: '取消',
+    defaultTitle: '資訊',
+    prompt: {
+      InputLengthPrompt: '最多輸入 {length} 個字符'
+    },
+    photos: {
+      noData: '沒有圖片',
+      tools:{
+        rotate: '旋轉',
+        scaleX: '水平變換',
+        zoomIn: '放大',
+        zoomOut: '縮小',
+        reset: '還原',
+        close: '關閉'
+      },
+      viewPicture: '查看原圖',
+      urlError: {
+        prompt: '當前圖片地址異常，<br>是否繼續查看下一張？',
+        confirm: '下一張',
+        cancel: '不看了'
+      }
+    }
+  },
+  laypage: {
+    prev: '上一頁',
+    next: '下一頁',
+    first: '首頁',
+    last: '尾頁',
+    total: '共 {total} 條',
+    pagesize: '條/頁',
+    goto: '到第',
+    page: '頁',
+    confirm: '確定'
+  },
+  table: {
+    sort: {
+      asc: '升序',
+      desc: '降序'
+    },
+    noData: '無資料',
+    tools:{
+      filter: {
+        title: '篩選列'
+      },
+      export: {
+        title: '匯出',
+        noDataPrompt: '當前表格無資料',
+        compatPrompt: '匯出功能不支援 IE，請用 Chrome 等高級瀏覽器匯出',
+        csvText : '匯出 CSV 檔案'
+      },
+      print: {
+        title: '列印',
+        noDataPrompt: '當前表格無資料'
+      }
+    },
+    dataFormatError: '返回的資料不符合規範，正確的成功狀態碼應為："{statusName}": {statusCode}',
+    xhrError: '請求異常，錯誤提示：{msg}'
+  },
+  transfer: {
+    noData: '無資料',
+    noMatch: '無匹配資料',
+    title: ['列表一', '列表二'],
+    searchPlaceholder: '關鍵詞搜尋'
+  },
+  tree: {
+    defaultNodeName: '未命名',
+    noData: '無資料',
+    deleteNodePrompt: '確認刪除"{name}"節點嗎？'
+  },
+  upload: {
+    fileType: {
+      file: '檔案',
+      image: '圖片',
+      video: '影片',
+      audio: '音訊'
+    },
+    validateMessages: {
+      fileExtensionError: '選擇的{fileType}中包含不支援的格式',
+      filesOverLengthLimit: '同時最多只能上傳: {length} 個檔案',
+      currentFilesLength: '您當前已經選擇了: {length} 個檔案',
+      fileOverSizeLimit: '檔案大小不能超過 {size}'
+    },
+    chooseText: '{length} 個檔案'
+  },
+  util: {
+    timeAgo: {
+      days: '{days} 天前',
+      hours: '{hours} 小時前',
+      minutes: '{minutes} 分鐘前',
+      future: '未來',
+      justNow: '剛剛'
+    },
+    toDateString: {
+      meridiem: function(hours, minutes){
+        var hm = hours * 100 + minutes;
+        if (hm < 600) {
+          return '凌晨';
+        } else if (hm < 900) {
+          return '早上';
+        } else if (hm < 1100) {
+          return '上午';
+        } else if (hm < 1300) {
+          return '中午';
+        } else if (hm < 1800) {
+          return '下午';
+        }
+        return '晚上';
+      }
+    }
+  }
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ const config = {
     {pkg: pkg, js: ';'}
   ],
   // 全部模块
-  modules: 'lay,laytpl,laypage,laydate,jquery,component,layer,util,dropdown,slider,colorpicker,element,upload,form,table,treeTable,tabs,tree,transfer,carousel,rate,flow,code'
+  modules: 'lay,i18n,laytpl,laypage,laydate,jquery,component,layer,util,dropdown,slider,colorpicker,element,upload,form,table,treeTable,tabs,tree,transfer,carousel,rate,flow,code'
 };
 
 // 获取参数

--- a/src/layui.js
+++ b/src/layui.js
@@ -11,212 +11,11 @@
   var document = window.document;
   var location = window.location;
 
-  // 中文国际化消息对象
-  var zhCN = {
-    locale: 'zh-cn',
-    code: {
-      copy: '复制代码',
-      copied: '已复制',
-      copyError: '复制失败',
-      maximize: '最大化显示',
-      restore: '还原显示',
-      preview: '在新窗口预览'
-    },
-    colorpicker: {
-      clear: '清除',
-      confirm: '确定'
-    },
-    dropdown: {
-      noData: '暂无数据'
-    },
-    flow: {
-      loadMore: '加载更多',
-      noMore: '没有更多了'
-    },
-    form: {
-      select: {
-        noData: '暂无数据',
-        noMatch: '无匹配数据',
-        placeholder: '请选择'
-      },
-      validateMessages: {
-        required: '必填项不能为空',
-        phone: '手机号格式不正确',
-        email: '邮箱格式不正确',
-        url: '链接格式不正确',
-        number: '只能填写数字',
-        date: '日期格式不正确',
-        identity: '身份证号格式不正确'
-      },
-      verifyErrorPromptTitle: '提示'
-    },
-    laydate: {
-      // 未使用的字段为保留字段，将来可能会使用
-      month: {
-        long: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'],
-        short: ['一', '二', '三', '四', '五', '六', '七', '八', '九', '十', '十一', '十二']
-      },
-      week: {
-        long: ['周日', '周一', '周二', '周三', '周四', '周五', '周六'],
-        short: ['日', '一', '二', '三', '四', '五', '六']
-      },
-      time: ['时', '分', '秒'],
-      selectTime: '选择时间',
-      startTime: '开始时间',
-      endTime: '结束时间',
-      selectDate: '选择日期',
-      tools: {
-        confirm: '确定',
-        clear: '清空',
-        now: '现在',
-        reset: '重置'
-      },
-      timeout: {
-        date: '结束日期不能早于开始日期<br>请重新选择',
-        time: '结束时间不能早于开始时间<br>请重新选择'
-      },
-      invalidDate: '不在有效日期或时间范围内',
-      formatError: ['日期格式不合法<br>必须遵循下述格式：<br>', '<br>已为你重置'],
-      preview: '当前选中的结果',
-      // IE11- Date.prototype.toLocaleDateString 不支持第二个参数，所以此处用函数实现
-      panelHeaderFormat: {
-        year: function (y) { return y + ' 年' },
-        month: function (m) { return m + ' 月' },
-        monthBeforeYear: false
-      },
-      // 面板中某些字符串拼接使用
-      view: {
-        year: '年',
-        month: '月',
-        week: '周',
-        day: '天'
-      }
-    },
-    layer: {
-      confirm: '确定',
-      cancel: '取消',
-      defaultTitle: '信息',
-      prompt: {
-        InputLengthPrompt: '最多输入 {length} 个字符'
-      },
-      photos: {
-        noData: '没有图片',
-        tools:{
-          rotate: '旋转',
-          scaleX: '水平变换',
-          zoomIn: '放大',
-          zoomOut: '缩小',
-          reset: '还原',
-          close: '关闭'
-        },
-        viewPicture: '查看原图',
-        urlError: {
-          prompt: '当前图片地址异常，<br>是否继续查看下一张？',
-          confirm: '下一张',
-          cancel: '不看了'
-        }
-      }
-    },
-    laypage: {
-      prev: '上一页',
-      next: '下一页',
-      first: '首页',
-      last: '尾页',
-      total: '共 {total} 条',
-      pagesize: '条/页',
-      goto: '到第',
-      page: '页',
-      confirm: '确定'
-    },
-    table: {
-      sort: {
-        asc: '升序',
-        desc: '降序'
-      },
-      noData: '无数据',
-      tools:{
-        filter: {
-          title: '筛选列'
-        },
-        export: {
-          title: '导出',
-          noDataPrompt: '当前表格无数据',
-          compatPrompt: '导出功能不支持 IE，请用 Chrome 等高级浏览器导出',
-          csvText : '导出 CSV 文件'
-        },
-        print: {
-          title: '打印',
-          noDataPrompt: '当前表格无数据'
-        }
-      },
-      dataFormatError: '返回的数据不符合规范，正确的成功状态码应为："{statusName}": {statusCode}',
-      xhrError: '请求异常，错误提示：{msg}'
-    },
-    transfer: {
-      noData: '无数据',
-      noMatch: '无匹配数据',
-      title: ['列表一', '列表二'],
-      searchPlaceholder: '关键词搜索'
-    },
-    tree: {
-      defaultNodeName: '未命名',
-      noData: '无数据',
-      deleteNodePrompt: '确认删除"{name}"节点吗？'
-    },
-    upload: {
-      fileType: {
-        file: '文件',
-        image: '图片',
-        video: '视频',
-        audio: '音频'
-      },
-      validateMessages: {
-        fileExtensionError: '选择的{fileType}中包含不支持的格式',
-        filesOverLengthLimit: '同时最多只能上传: {length} 个文件',
-        currentFilesLength: '您当前已经选择了: {length} 个文件',
-        fileOverSizeLimit: '文件大小不能超过 {size}'
-      },
-      chooseText: '{length} 个文件' 
-    },
-    util: {
-      timeAgo: {
-        days: '{days} 天前',
-        hours: '{hours} 小时前',
-        minutes: '{minutes} 分钟前',
-        future: '未来',
-        justNow: '刚刚'
-      },
-      toDateString: {
-        meridiem: function(hours, minutes){
-          var hm = hours * 100 + minutes;
-          if (hm < 600) {
-            return '凌晨';
-          } else if (hm < 900) {
-            return '早上';
-          } else if (hm < 1100) {
-            return '上午';
-          } else if (hm < 1300) {
-            return '中午';
-          } else if (hm < 1800) {
-            return '下午';
-          }
-          return '晚上';
-        }
-      }
-    }
-  }
-
   // 基础配置
   var config = {
     timeout: 10, // 符合规范的模块请求最长等待秒数
     debug: false, // 是否开启调试模式
-    version: false, // 是否在模块请求时加入版本号参数（以更新模块缓存）
-    i18n:{
-      locale: 'zh-cn', // 全局内置语言
-      messages: { // 全局国际化消息对象
-        'zh-cn': zhCN
-      }
-    }
+    version: false // 是否在模块请求时加入版本号参数（以更新模块缓存）
   };
 
   // 模块加载缓存信息
@@ -234,8 +33,6 @@
 
   // 识别预先可能定义的指定全局对象
   var GLOBAL = window.LAYUI_GLOBAL || {};
-  var OBJECT_REPLACE_REGEX = /\{(\w+)\}/g;
-  var INDEX_REPLACE_REGEX = /\{(\d+)\}/g;
 
   // 获取 layui 所在目录
   var getPath = function() {
@@ -258,12 +55,10 @@
   // 异常提示
   var error = function(msg, type) {
     type = type || 'log';
-    msg = 'layui error hint: ' + msg
+    msg = 'Layui message: ' + msg;
 
-    if (window.console && console[type]) {
-      console[type](msg);
-    } else if (window.console && console.log) {
-      console.log(msg);
+    if (window.console) {
+      console[type] ? console[type](msg) : console.log(msg);
     }
   };
 
@@ -292,6 +87,7 @@
     code: 'code', // 代码修饰器
     jquery: 'jquery', // DOM 库（第三方）
     component: 'component', // 组件构建器
+    i18n:  'i18n', // 国际化
 
     all: 'all',
     'layui.all': 'layui.all' // 聚合标识（功能性的，非真实模块）
@@ -371,16 +167,9 @@
   /**
    * 全局配置
    * @param {Object} options - 配置对象
-   * @param {boolean} deepMerge - 是否深度合并配置信息，默认为 false
    */
-  Class.prototype.config = function(options, deepMerge) {
-
-    if(deepMerge){
-      deepClone(config, options);
-    }else{
-      Object.assign(config, options);
-    }
-
+  Class.prototype.config = function(options) {
+    Object.assign(config, options);
     return this;
   };
 
@@ -1243,147 +1032,6 @@
         }, wait);
       }
     }
-  };
-
-  /**
-   * 根据给定的键从国际化消息中获取翻译后的内容
-   * 
-   * 未文档化的私有方法，仅限内部使用
-   * 
-   * @overload
-   * @param {string} key 要翻译的键
-   * @param {Record<string, any>} opts 国际化消息对象，替换 {key} 形式的占位符
-   * @returns {string} 翻译后的文本
-   * @example
-   * ```
-   * message: {
-   *   hello: '{msg} world'
-   * }
-   * layui.$t('message.hello', {msg: 'Hello'})
-   * ```
-   * 
-   * @overload
-   * @param {string} key 要翻译的键
-   * @param {any[]} opts 国际化消息数组，替换 {0}, {1}... 形式的占位符
-   * @returns {string} 翻译后的文本
-   * @example
-   * ```
-   * message: {
-   *   hello: '{0} world'
-   * }
-   * layui.$t('message.hello', ['Hello'])
-   * ```
-   * 
-   * @overload
-   * @param {string} key 要翻译的键
-   * @param {...*} args 国际化消息可变参数，替换 {0}, {1}... 形式的占位符
-   * @returns {string} 翻译后的文本
-   * @example
-   * ```
-   * message: {
-   *   hello: '{0} world'
-   * }
-   * layui.$t('message.hello', 'Hello')
-   * ```
-   * @internal
-   * @param {string} key
-   * @param {any[]} args
-   */
-  Class.prototype.i18nTranslation = function(key){
-    var that = this;
-    var args = arguments;
-    
-    var i18n = that.cache.i18n;
-    var i18nMessage = i18n.messages[i18n.locale];
-
-    if(!i18nMessage){
-      error('Locale "' + i18n.locale + '" not found. Please add i18n messages for this locale first.', 'warn');
-      return key;
-    }
-
-    var result = get(i18nMessage, key, key);
-
-    // 替换占位符
-    if(typeof result === 'string' && args.length > 1){
-      var opts = args[1];
-      // 第二个参数为对象或数组，替换占位符 {key} 或 {0}, {1}...
-      if(opts !== null && typeof opts === 'object'){
-        return result.replace(OBJECT_REPLACE_REGEX, function(match, key) {
-          return opts[key] !== undefined ? opts[key] : match;
-        });
-      }
-
-      // 处理可变参数，替换占位符 {0}, {1}...
-      return result.replace(INDEX_REPLACE_REGEX, function(match, index) {
-        var arg = args[index + 1];
-        return arg !== undefined ? arg : match;
-      });
-    }
-
-    return result;
-  };
-
-  /**
-   * 根据给定的键从国际化消息中获取翻译后的内容
-   * 
-   * layui.i18nTranslation 的别名，用于简化代码书写，未文档化仅限内部使用
-   */
-  Class.prototype.$t = Class.prototype.i18nTranslation;
-
-  /**
-   * 获取对象中的值，lodash _.get 简易版
-   * @param {Record<string, any>} obj 
-   * @param {string} path 
-   * @param {any} defaultValue 
-   */
-  function get(obj, path, defaultValue){
-    // 'a[0].b.c' ==> ['a', '0', 'b', 'c']
-    var casePath = path.replace(/\[(\d+)\]/g, '.$1').split('.');
-    var result = obj;
-
-    for(var i = 0; i < casePath.length; i++) {
-      result = result && result[casePath[i]];
-      if(result === null || result === undefined){
-        return defaultValue;
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * 将两个或多个对象的内容深度合并到第一个对象中
-   * 复制自 lay.extend
-   * @callback ExtendFunc
-   * @param {*} target - 一个对象
-   * @param {...*} objectN - 包含额外的属性合并到第一个参数
-   * @returns {*} 返回合并后的对象
-   */
-  /** @type ExtendFunc*/
-  function deepClone(){
-    var ai = 1;
-    var length;
-    var args = arguments;
-    var clone = function(target, obj){
-      target = target || (layui.type(obj) === 'array' ? [] : {}); // 目标对象
-      for(var i in obj){
-        // 若值为普通对象，则进入递归，继续深度合并
-        target[i] = (obj[i] && obj[i].constructor === Object)
-          ? clone(target[i], obj[i])
-        : obj[i];
-      }
-      return target;
-    };
-
-    args[0] = typeof args[0] === 'object' ? args[0] : {};
-    length = args.length
-
-    for(; ai < length; ai++){
-      if(typeof args[ai] === 'object'){
-        clone(args[0], args[ai]);
-      }
-    }
-    return args[0];
   };
 
   // export layui

--- a/src/modules/code.js
+++ b/src/modules/code.js
@@ -3,7 +3,7 @@
  * Code 预览组件
  */
 
-layui.define(['lay', 'util', 'element', 'tabs', 'form'], function(exports){
+layui.define(['lay', 'i18n', 'util', 'element', 'tabs', 'form'], function(exports) {
   "use strict";
 
   var $ = layui.$;
@@ -13,6 +13,7 @@ layui.define(['lay', 'util', 'element', 'tabs', 'form'], function(exports){
   var form = layui.form;
   var layer = layui.layer;
   var hint = layui.hint();
+  var i18n = layui.i18n;
 
   // 常量
   var CONST = {
@@ -201,7 +202,7 @@ layui.define(['lay', 'util', 'element', 'tabs', 'form'], function(exports){
     var tools = {
       copy: {
         className: 'file-b',
-        title: [layui.$t('code.copy')],
+        title: [i18n.$t('code.copy')],
         event: function(obj){
           var code = util.unescape(finalCode(options.code));
           var hasOnCopy = typeof options.onCopy === 'function';
@@ -215,14 +216,14 @@ layui.define(['lay', 'util', 'element', 'tabs', 'form'], function(exports){
                 if(ret === false) return;
               }
 
-              layer.msg(layui.$t('code.copied'), {icon: 1});
+              layer.msg(i18n.$t('code.copied'), {icon: 1});
             },
             error: function() {
               if(hasOnCopy){
                 var ret = options.onCopy(code, false);
                 if(ret === false) return;
               }
-              layer.msg(layui.$t('code.copyError'), {icon: 2});
+              layer.msg(i18n.$t('code.copyError'), {icon: 2});
             }
           });
         }
@@ -277,7 +278,7 @@ layui.define(['lay', 'util', 'element', 'tabs', 'form'], function(exports){
       $.extend(tools, {
         'full': {
           className: 'screen-full',
-          title: [layui.$t('code.maximize'), layui.$t('code.restore')],
+          title: [i18n.$t('code.maximize'), i18n.$t('code.restore')],
           event: function(obj){
             var el = obj.elem;
             var elemView = el.closest('.'+ CONST.ELEM_PREVIEW);
@@ -302,7 +303,7 @@ layui.define(['lay', 'util', 'element', 'tabs', 'form'], function(exports){
         },
         'window': {
           className: 'release',
-          title: [layui.$t('code.preview')],
+          title: [i18n.$t('code.preview')],
           event: function(obj){
             util.openWin({
               content: finalCode(options.code)
@@ -563,7 +564,7 @@ layui.define(['lay', 'util', 'element', 'tabs', 'form'], function(exports){
     if(options.copy && !options.preview){
       var copyElem = $([
         '<span class="layui-code-copy">',
-        '<i class="layui-icon layui-icon-file-b" title="' + layui.$t('code.copy') + '"></i>',
+        '<i class="layui-icon layui-icon-file-b" title="' + i18n.$t('code.copy') + '"></i>',
         '</span>'
       ].join(''));
 

--- a/src/modules/colorpicker.js
+++ b/src/modules/colorpicker.js
@@ -3,12 +3,13 @@
  * 颜色选择组件
  */
 
-layui.define(['jquery', 'lay'], function(exports) {
+layui.define(['i18n', 'jquery', 'lay'], function(exports) {
   "use strict";
 
   var $ = layui.$;
   var lay = layui.lay;
   var hint = layui.hint();
+  var i18n = layui.i18n;
   var device = layui.device();
   var clickOrMousedown = (device.mobile ? 'click' : 'mousedown');
 
@@ -285,8 +286,8 @@ layui.define(['jquery', 'lay'], function(exports) {
           ,'<input type="text" class="layui-input">'
         ,'</div>'
         ,'<div class="layui-btn-group">'
-          ,'<button style="border-radius: 0" class="layui-btn layui-btn-primary layui-btn-sm" colorpicker-events="clear">' + layui.$t('colorpicker.clear') + '</button>'
-          ,'<button style="border-radius: 0; border-left: 0" class="layui-btn layui-btn-primary layui-btn-sm" colorpicker-events="confirm">' + layui.$t('colorpicker.confirm')  + '</button>'
+          ,'<button style="border-radius: 0" class="layui-btn layui-btn-primary layui-btn-sm" colorpicker-events="clear">' + i18n.$t('colorpicker.clear') + '</button>'
+          ,'<button style="border-radius: 0; border-left: 0" class="layui-btn layui-btn-primary layui-btn-sm" colorpicker-events="confirm">' + i18n.$t('colorpicker.confirm')  + '</button>'
         ,'</div'
       ,'</div>'
     ,'</div>'].join(''))

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -3,13 +3,14 @@
  * 下拉菜单组件
  */
 
-layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports) {
+layui.define(['i18n', 'jquery', 'laytpl', 'lay', 'util'], function(exports) {
   "use strict";
 
   var $ = layui.$;
   var laytpl = layui.laytpl;
   var util = layui.util;
   var hint = layui.hint();
+  var i18n = layui.i18n;
   var device = layui.device();
   var clickOrMousedown = (device.mobile ? 'touchstart' : 'mousedown');
 
@@ -181,7 +182,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports) {
       if(options.data.length > 0 ){
         eachItemView(elemUl, options.data)
       } else {
-        elemUl.html('<li class="layui-menu-item-none">' + layui.$t('dropdown.noData') + '</li>');
+        elemUl.html('<li class="layui-menu-item-none">' + i18n.$t('dropdown.noData') + '</li>');
       }
       return elemUl;
     };
@@ -569,7 +570,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports) {
       that.remove();
     }, lay.passiveSupported ? { passive: false} : false);
 
-    // onClickOutside 检测 iframe 
+    // onClickOutside 检测 iframe
     _WIN.on('blur', function(e){
       if(!dropdown.thisId) return;
       var that = thisModule.getThis(dropdown.thisId)

--- a/src/modules/flow.js
+++ b/src/modules/flow.js
@@ -3,10 +3,11 @@
  */
 
 
-layui.define('jquery', function(exports) {
+layui.define(['i18n', 'jquery'], function(exports) {
   "use strict";
 
   var $ = layui.$;
+  var i18n = layui.i18n;
   var Flow = function(options) {};
   var ELEM_MORE = 'layui-flow-more';
   var ELEM_LOAD = '<i class="layui-anim layui-anim-rotate layui-anim-loop layui-icon ">&#xe63e;</i>';
@@ -20,8 +21,8 @@ layui.define('jquery', function(exports) {
     var scrollElem = $(options.scrollElem || document); // 滚动条所在元素
     var threshold = 'mb' in options ? options.mb : 50; // 临界距离
     var isAuto = 'isAuto' in options ? options.isAuto : true; // 否自动滚动加载
-    var moreText = options.moreText || layui.$t('flow.loadMore'); // 手动加载时，加载更多按钮文案
-    var end = options.end || layui.$t('flow.noMore'); // “末页”显示文案
+    var moreText = options.moreText || i18n.$t('flow.loadMore'); // 手动加载时，加载更多按钮文案
+    var end = options.end || i18n.$t('flow.noMore'); // “末页”显示文案
     var direction = options.direction || 'bottom';
     var isTop = direction === 'top';
 

--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -2,7 +2,7 @@
  * form 表单组件
  */
 
-layui.define(['lay', 'layer', 'util'], function(exports){
+layui.define(['lay', 'i18n', 'layer', 'util'], function(exports){
   "use strict";
 
   var $ = layui.$;
@@ -10,6 +10,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
   var util = layui.util;
   var hint = layui.hint();
   var device = layui.device();
+  var i18n = layui.i18n;
 
   var MOD_NAME = 'form';
   var ELEM = '.layui-form';
@@ -31,42 +32,42 @@ layui.define(['lay', 'layer', 'util'], function(exports){
       verify: {
         required: function(value) {
           if (!/[\S]+/.test(value) || value === undefined || value === null) {
-            return layui.$t('form.validateMessages.required');
+            return i18n.$t('form.validateMessages.required');
           }
         },
         phone: function(value) {
           var EXP = /^1\d{10}$/;
           if (value && !EXP.test(value)) {
-            return layui.$t('form.validateMessages.phone');
+            return i18n.$t('form.validateMessages.phone');
           }
         },
         email: function(value) {
           var EXP = /^([a-zA-Z0-9_\.\-])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/;
           if (value && !EXP.test(value)) {
-            return layui.$t('form.validateMessages.email');
+            return i18n.$t('form.validateMessages.email');
           }
         },
         url: function(value) {
           var EXP = /^(#|(http(s?)):\/\/|\/\/)[^\s]+\.[^\s]+$/;
           if (value && !EXP.test(value)) {
-            return layui.$t('form.validateMessages.url');
+            return i18n.$t('form.validateMessages.url');
           }
         },
         number: function(value){
           if (value && isNaN(value)) {
-            return layui.$t('form.validateMessages.number');
+            return i18n.$t('form.validateMessages.number');
           }
         },
         date: function(value){
           var EXP = /^(\d{4})[-\/](\d{1}|0\d{1}|1[0-2])([-\/](\d{1}|0\d{1}|[1-2][0-9]|3[0-1]))*$/;
           if (value && !EXP.test(value)) {
-            return layui.$t('form.validateMessages.date');
+            return i18n.$t('form.validateMessages.date');
           }
         },
         identity: function(value) {
           var EXP = /(^\d{15}$)|(^\d{17}(x|X|\d)$)/;
           if (value && !EXP.test(value)) {
-            return layui.$t('form.validateMessages.identity');
+            return i18n.$t('form.validateMessages.identity');
           }
         }
       },
@@ -466,7 +467,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
 
       // 下拉选择框
       ,select: function(elem){
-        var TIPS = layui.$t('form.select.placeholder');
+        var TIPS = i18n.$t('form.select.placeholder');
         var CLASS = 'layui-form-select';
         var TITLE = 'layui-select-title';
         var NONE = 'layui-select-none';
@@ -765,7 +766,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
                 }
               }else{
                 if(none){
-                  dl.find('.'+NONE)[0] || dl.append('<p class="'+ NONE + '">' + layui.$t('form.select.noMatch') + '</p>');
+                  dl.find('.'+NONE)[0] || dl.append('<p class="'+ NONE + '">' + i18n.$t('form.select.noMatch') + '</p>');
                 } else {
                   dl.find('.'+NONE).remove();
                 }
@@ -956,7 +957,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
                 }
               });
               if (arr.length === 0) {
-                arr.push('<dd lay-value="" class="'+ DISABLED + '">' + layui.$t('form.select.noData') + '</dd>');
+                arr.push('<dd lay-value="" class="'+ DISABLED + '">' + i18n.$t('form.select.noData') + '</dd>');
               }
               return arr.join('');
             }();
@@ -1367,7 +1368,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
                 return othis;
               }(), {tips: 1});
             } else if(verType === 'alert') {
-              layer.alert(errorText, {title: layui.$t('form.verifyErrorPromptTitle'), shadeClose: true});
+              layer.alert(errorText, {title: i18n.$t('form.verifyErrorPromptTitle'), shadeClose: true});
             }
             // 若返回的为字符或数字，则自动弹出默认提示框；否则由 verify 方法中处理提示
             else if(/\b(string|number)\b/.test(typeof errorText)) {

--- a/src/modules/i18n.js
+++ b/src/modules/i18n.js
@@ -1,0 +1,276 @@
+/**
+ * i18n
+ * 国际化
+ */
+
+layui.define('lay', function(exports) {
+  'use strict';
+
+  var lay = layui.lay;
+  var hint  = layui.hint();
+
+  var MOD_NAME = 'i18n';
+
+  // 识别预先可能定义的指定全局对象
+  var GLOBAL = window.LAYUI_GLOBAL || {};
+
+  // 简体中文
+  var zhCN = {
+    code: {
+      copy: '复制代码',
+      copied: '已复制',
+      copyError: '复制失败',
+      maximize: '最大化显示',
+      restore: '还原显示',
+      preview: '在新窗口预览'
+    },
+    colorpicker: {
+      clear: '清除',
+      confirm: '确定'
+    },
+    dropdown: {
+      noData: '暂无数据'
+    },
+    flow: {
+      loadMore: '加载更多',
+      noMore: '没有更多了'
+    },
+    form: {
+      select: {
+        noData: '暂无数据',
+        noMatch: '无匹配数据',
+        placeholder: '请选择'
+      },
+      validateMessages: {
+        required: '必填项不能为空',
+        phone: '手机号格式不正确',
+        email: '邮箱格式不正确',
+        url: '链接格式不正确',
+        number: '只能填写数字',
+        date: '日期格式不正确',
+        identity: '身份证号格式不正确'
+      },
+      verifyErrorPromptTitle: '提示'
+    },
+    layer: {
+      confirm: '确定',
+      cancel: '取消',
+      defaultTitle: '信息',
+      prompt: {
+        InputLengthPrompt: '最多输入 {length} 个字符'
+      },
+      photos: {
+        noData: '没有图片',
+        tools:{
+          rotate: '旋转',
+          scaleX: '水平变换',
+          zoomIn: '放大',
+          zoomOut: '缩小',
+          reset: '还原',
+          close: '关闭'
+        },
+        viewPicture: '查看原图',
+        urlError: {
+          prompt: '当前图片地址异常，<br>是否继续查看下一张？',
+          confirm: '下一张',
+          cancel: '不看了'
+        }
+      }
+    },
+    laypage: {
+      prev: '上一页',
+      next: '下一页',
+      first: '首页',
+      last: '尾页',
+      total: '共 {total} 条',
+      pagesize: '条/页',
+      goto: '到第',
+      page: '页',
+      confirm: '确定'
+    },
+    table: {
+      sort: {
+        asc: '升序',
+        desc: '降序'
+      },
+      noData: '无数据',
+      tools:{
+        filter: {
+          title: '筛选列'
+        },
+        export: {
+          title: '导出',
+          noDataPrompt: '当前表格无数据',
+          compatPrompt: '导出功能不支持 IE，请用 Chrome 等高级浏览器导出',
+          csvText : '导出 CSV 文件'
+        },
+        print: {
+          title: '打印',
+          noDataPrompt: '当前表格无数据'
+        }
+      },
+      dataFormatError: '返回的数据不符合规范，正确的成功状态码应为："{statusName}": {statusCode}',
+      xhrError: '请求异常，错误提示：{msg}'
+    },
+    transfer: {
+      noData: '无数据',
+      noMatch: '无匹配数据',
+      title: ['列表一', '列表二'],
+      searchPlaceholder: '关键词搜索'
+    },
+    tree: {
+      defaultNodeName: '未命名',
+      noData: '无数据',
+      deleteNodePrompt: '确认删除"{name}"节点吗？'
+    },
+    upload: {
+      fileType: {
+        file: '文件',
+        image: '图片',
+        video: '视频',
+        audio: '音频'
+      },
+      validateMessages: {
+        fileExtensionError: '选择的{fileType}中包含不支持的格式',
+        filesOverLengthLimit: '同时最多只能上传: {length} 个文件',
+        currentFilesLength: '您当前已经选择了: {length} 个文件',
+        fileOverSizeLimit: '文件大小不能超过 {size}'
+      },
+      chooseText: '{length} 个文件'
+    },
+    util: {
+      timeAgo: {
+        days: '{days} 天前',
+        hours: '{hours} 小时前',
+        minutes: '{minutes} 分钟前',
+        future: '未来',
+        justNow: '刚刚'
+      },
+      toDateString: {
+        meridiem: function(hours, minutes){
+          var hm = hours * 100 + minutes;
+          if (hm < 600) {
+            return '凌晨';
+          } else if (hm < 900) {
+            return '早上';
+          } else if (hm < 1100) {
+            return '上午';
+          } else if (hm < 1300) {
+            return '中午';
+          } else if (hm < 1800) {
+            return '下午';
+          }
+          return '晚上';
+        }
+      }
+    }
+  };
+
+  // 默认配置
+  var config = lay.extend({
+    locale: 'zh-CN', // 全局内置语言
+    messages: { // 全局国际化消息对象
+      'zh-CN': zhCN
+    }
+  }, GLOBAL.i18n); // 读取全局预设配置，确保打包后的版本初始调用时机
+
+  var OBJECT_REPLACE_REGEX = /\{(\w+)\}/g;
+  var INDEX_REPLACE_REGEX = /\{(\d+)\}/g;
+
+  /**
+   * 获取对象中的值，lodash _.get 简易版
+   * @param {Record<string, any>} obj
+   * @param {string} path
+   * @param {any} defaultValue
+   */
+  function get(obj, path, defaultValue) {
+    // 'a[0].b.c' ==> ['a', '0', 'b', 'c']
+    var casePath = path.replace(/\[(\d+)\]/g, '.$1').split('.');
+    var result = obj;
+
+    for(var i = 0; i < casePath.length; i++) {
+      result = result && result[casePath[i]];
+      if(result === null || result === undefined){
+        return defaultValue;
+      }
+    }
+
+    return result;
+  }
+
+  var i18n = {
+    config: config,
+    set: function(options) {
+      lay.extend(config, options);
+    }
+  };
+
+  /**
+   * 根据给定的键从国际化消息中获取翻译后的内容
+   * 未文档化的私有方法，仅限内部使用
+   *
+   * @internal
+   * @param {string} key 要翻译的键
+   * @param {Record<string, any> | any[] | ...any} [args] 可选的占位符替换参数：
+   * - 对象形式：用于替换 `{key}` 形式的占位符；
+   * - 数组形式：用于替换 `{0}`, `{1}` 等占位符；
+   * - 可变参数：用于替换 `{0}`, `{1}` 等占位符。
+   * @returns {string} 翻译后的文本
+   *
+   * @example 使用对象替换命名占位符
+   * message: {
+   *   hello: '{msg} world'
+   * }
+   * i18n.$t('message.hello', { msg: 'Hello' })
+   *
+   * @example 使用数组替换索引占位符
+   * message: {
+   *   hello: '{0} world'
+   * }
+   * i18n.$t('message.hello', ['Hello'])
+   *
+   * @example 使用变长参数替换索引占位符
+   * message: {
+   *   hello: '{0} world'
+   * }
+   * i18n.$t('message.hello', 'Hello')
+   */
+  i18n.translation = function(key) {
+    var options = config;
+    var args = arguments;
+    var i18nMessage = options.messages[options.locale];
+
+    if (!i18nMessage) {
+      hint.error('Locale "' + options.locale + '" not found. Please add i18n messages for this locale first.', 'warn');
+      return key;
+    }
+
+    var result = get(i18nMessage, key, key);
+
+    // 替换占位符
+    if (typeof result === 'string' && args.length > 1) {
+      var opts = args[1];
+      // 第二个参数为对象或数组，替换占位符 {key} 或 {0}, {1}...
+      if (opts !== null && typeof opts === 'object') {
+        return result.replace(OBJECT_REPLACE_REGEX, function(match, key) {
+          return opts[key] !== undefined ? opts[key] : match;
+        });
+      }
+
+      // 处理可变参数，替换占位符 {0}, {1}...
+      return result.replace(INDEX_REPLACE_REGEX, function(match, index) {
+        var arg = args[index + 1];
+        return arg !== undefined ? arg : match;
+      });
+    }
+
+    return result;
+  };
+
+  /**
+   * i18n.translation 的别名，用于简化代码书写，未文档化仅限内部使用
+   */
+  i18n.$t = i18n.translation;
+
+  exports(MOD_NAME, i18n);
+});

--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -176,8 +176,7 @@
     ,showBottom: true //是否显示底部栏
     ,isPreview: true //是否显示值预览
     ,btns: ['clear', 'now', 'confirm'] //右下角显示的按钮，会按照数组顺序排列
-    // 为实现 lang 选项就近生效，去除此处的默认值，原型 lang() 方法中有兜底值
-    ,lang: '' //语言，只支持cn/en，即中文和英文
+    ,lang: 'cn' // 语言，只支持 cn/en，即中文和英文
     ,theme: 'default' //主题
     ,position: null //控件定位方式定位, 默认absolute，支持：fixed/absolute/static
     ,calendar: false //是否开启公历重要节日，仅支持中文版
@@ -190,60 +189,32 @@
     ,shade: 0
   };
 
-  //多语言
-  Class.prototype.lang = function(){
+  // 多语言
+  Class.prototype.lang = function() {
     var that = this;
     var options = that.config;
     var text = {
       cn: {
-        month: {
-          long: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'],
-          short: ['一', '二', '三', '四', '五', '六', '七', '八', '九', '十', '十一', '十二']
-        },
-        week: {
-          long: ['周日', '周一', '周二', '周三', '周四', '周五', '周六'],
-          short: ['日', '一', '二', '三', '四', '五', '六']
-        },
+        month: ['一', '二', '三', '四', '五', '六', '七', '八', '九', '十', '十一', '十二'],
+        weeks: ['日', '一', '二', '三', '四', '五', '六'],
         time: ['时', '分', '秒'],
         selectTime: '选择时间',
         startTime: '开始时间',
         endTime: '结束时间',
-        selectDate: '选择日期',
+        selectDate: '返回日期',
         tools: {
           confirm: '确定',
           clear: '清空',
-          now: '现在',
-          reset: '重置'
+          now: '现在'
         },
-        timeout: {
-          date: '结束日期不能早于开始日期<br>请重新选择',
-          time: '结束时间不能早于开始时间<br>请重新选择'
-        },
+        timeout: '结束时间不能早于开始时间<br>请重新选择',
         invalidDate: '不在有效日期或时间范围内',
         formatError: ['日期格式不合法<br>必须遵循下述格式：<br>', '<br>已为你重置'],
-        preview: '当前选中的结果',
-        panelHeaderFormat: {
-          year: function (y) { return y + ' 年' },
-          month: function (m) { return m + ' 月' },
-          monthBeforeYear: false
-        },
-        /** 面板中某些字符串拼接使用 */
-        view: {
-          year: '年',
-          month: '月',
-          week: '周',
-          day: '天'
-        },
+        preview: '当前选中的结果'
       },
       en: {
-        month: {
-          long: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-          short: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-        },
-        week: {
-          long: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-          short: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
-        },
+        month: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+        weeks: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
         time: ['Hours', 'Minutes', 'Seconds'],
         selectTime: 'Select Time',
         startTime: 'Start Time',
@@ -252,55 +223,28 @@
         tools: {
           confirm: 'Confirm',
           clear: 'Clear',
-          now: 'Now',
-          reset: 'Reset'
+          now: 'Now'
         },
-        timeout: {
-          date: 'End time cannot be less than start Time<br>Please re-select',
-          time: 'End time cannot be less than start Time<br>Please re-select'
-        },
+        timeout: 'End time cannot be less than start Time<br>Please re-select',
         invalidDate: 'Invalid date',
         formatError: ['The date format error<br>Must be followed：<br>', '<br>It has been reset'],
-        preview: 'The selected result',
-        // IE11- Date.prototype.toLocaleDateString 不支持第二个参数，所以这里用函数实现，直接使用英文短格式
-        panelHeaderFormat: {
-          year: function (y) { return y},
-          month: function (m) { return text.en.month.short[m - 1]},
-          monthBeforeYear: true
-        },
-        /** 面板中某些字符串拼接使用 */
-        view: {
-          year: '',
-          month: '',
-          week: '',
-          day: ''
-        }
+        preview: 'The selected result'
       }
     };
 
-    if(isLayui){
-      var i18n = layui.cache.i18n;
-      var message = i18n.messages[i18n.locale];
-      if(message){
-        text[i18n.locale] = message.laydate;
-      }else{
-        window.console && console.log && console.log('layui[laydate]: Locale "' + i18n.locale + '" not found. Please add i18n messages for this locale first.');
-      }
-      // 同步 locale
-      if(!options.lang){
-        options.lang = i18n.locale;
+    // 为了避免边缘情况，laydate 只提供「简体中文」和「英文」切换
+    if (isLayui) {
+      var locale = layui.i18n.config.locale;
+      if (options.lang === 'cn' && locale !== 'zh-CN') {
+        options.lang = 'en';
       }
     }
 
-    if(!options.lang) {
-      options.lang = 'cn'
-    };
-
-    return text[options.lang];
+    return text[options.lang] || text['cn'];
   };
 
+  // 仅简体中文生效，不做国际化
   Class.prototype.markerOfChineseFestivals = {
-    // 仅 /cn/i 生效，不做国际化
     '0-1-1': '元旦',
     '0-2-14': '情人' ,
     '0-3-8': '妇女',
@@ -312,7 +256,7 @@
     '0-9-10': '教师',
     '0-10-1': '国庆',
     '0-12-25': '圣诞'
-  }
+  };
 
   // 重载实例
   Class.prototype.reload = function(options){
@@ -394,7 +338,7 @@
     if (options.weekStart) {
       if (!/^[0-6]$/.test(options.weekStart)) {
         var lang = that.lang();
-        options.weekStart = lang.week.short.indexOf(options.weekStart);
+        options.weekStart = lang.weeks.indexOf(options.weekStart);
         if (options.weekStart === -1) options.weekStart = 0;
       }
     }
@@ -617,7 +561,7 @@
         lay.each(new Array(7), function(j){
           if(i === 0){
             var th = lay.elem('th');
-            th.innerHTML = lang.week.short[(j + options.weekStart) % 7];
+            th.innerHTML = lang.weeks[(j + options.weekStart) % 7];
             theadTr.appendChild(th);
           }
           tr.insertCell(j);
@@ -651,7 +595,7 @@
       lay.each(options.btns, function(i, item){
         var title = lang.tools[item] || 'btn';
         if(options.range && item === 'now') return;
-        if(isStatic && item === 'clear') title = lang.tools.reset;
+        if(isStatic && item === 'clear') title = options.lang === 'cn' ? '重置' : 'Reset';
         btns.push('<span lay-type="'+ item +'" class="laydate-btns-'+ item +'">'+ title +'</span>');
       });
       html.push('<div class="laydate-footer-btns">'+ btns.join('') +'</div>');
@@ -1168,8 +1112,11 @@
     }
 
     // chineseFestivals 仅简体中文生效
-    if(options.calendar && /cn$/i.test(options.lang)){
-      render(that.markerOfChineseFestivals);
+    if (options.calendar) {
+      var isZhCN = isLayui ? layui.i18n.config.locale === 'zh-CN' : options.lang === 'cn';
+      if (isZhCN) {
+        render(that.markerOfChineseFestivals);
+      }
     }
 
     if(typeof options.mark === 'function'){
@@ -1566,16 +1513,13 @@
     if(!that.panelYM) that.panelYM = {};
     that.panelYM[index] = {year: dateTime.year, month: dateTime.month};
 
-    var formatArr = [
-      {type: 'year', value: lang.panelHeaderFormat.year(dateTime.year)},
-      {type: 'month', value: lang.panelHeaderFormat.month(dateTime.month + 1)}
-    ];
-    if(lang.panelHeaderFormat.monthBeforeYear){
-      formatArr = formatArr.reverse();
+    if(options.lang === 'cn'){
+      lay(elemYM[0]).attr('lay-type', 'year').html(dateTime.year + ' 年')
+      lay(elemYM[1]).attr('lay-type', 'month').html((dateTime.month + 1) + ' 月');
+    } else {
+      lay(elemYM[0]).attr('lay-type', 'month').html(lang.month[dateTime.month]);
+      lay(elemYM[1]).attr('lay-type', 'year').html(dateTime.year);
     }
-
-    lay(elemYM[0]).attr('lay-type', formatArr[0]['type']).html(formatArr[0]['value']);
-    lay(elemYM[1]).attr('lay-type', formatArr[1]['type']).html(formatArr[1]['value']);
 
     //初始默认选择器
     if(isAlone){ //年、月等独立选择器
@@ -1588,9 +1532,10 @@
           that.list(options.type, 0).list(options.type, 1);
 
           //同步按钮可点状态
-          options.type === 'time' ? that.setBtnStatus('isTime'
-            ,lay.extend({}, that.systemDate(), that.startTime)
-            ,lay.extend({}, that.systemDate(), that.endTime)
+          options.type === 'time' ? that.setBtnStatus(
+            true,
+            lay.extend({}, that.systemDate(), that.startTime),
+            lay.extend({}, that.systemDate(), that.endTime)
           ) : that.setBtnStatus(true);
         }
       } else {
@@ -1665,8 +1610,8 @@
     ,elemYM = lay(elemHeader[2]).find('span')
     ,elemCont = that.elemCont[index || 0]
     ,haveList = lay(elemCont).find('.'+ ELEM_LIST)[0]
-    ,isMonthBeforeYear = lang.panelHeaderFormat.monthBeforeYear
-    ,text = lang.view.year
+    ,isCN = options.lang === 'cn'
+    ,text = isCN ? '年' : ''
 
     ,listYM = that.listYM[index] || {}
     ,hms = ['hours', 'minutes', 'seconds']
@@ -1714,7 +1659,7 @@
         yearNum++;
       });
 
-      lay(elemYM[!isMonthBeforeYear ? 0 : 1]).attr('lay-ym', (yearNum - 8) + '-' + listYM[1])
+      lay(elemYM[isCN ? 0 : 1]).attr('lay-ym', (yearNum - 8) + '-' + listYM[1])
       .html((startY + text) + ' - ' + (yearNum - 1 + text));
     }
 
@@ -1731,7 +1676,7 @@
         };
 
         i + 1 == listYM[1] && lay(li).addClass(THIS);
-        li.innerHTML = lang.month.short[i] + lang.view.month;
+        li.innerHTML = lang.month[i] + (isCN ? '月' : '');
         ul.appendChild(li);
 
         /*
@@ -1753,7 +1698,7 @@
         that.cellRender(li, {year: listYM[0], month: i + 1, date: 1}, 'month');
       });
 
-      lay(elemYM[!isMonthBeforeYear ? 0 : 1]).attr('lay-ym', listYM[0] + '-' + listYM[1])
+      lay(elemYM[isCN ? 0 : 1]).attr('lay-ym', listYM[0] + '-' + listYM[1])
       .html(listYM[0] + text);
     }
 
@@ -1998,10 +1943,10 @@
         ? elemBtn.addClass(DISABLED)
       : elemBtn[isOut ? 'addClass' : 'removeClass'](DISABLED);
 
-      //是否异常提示
-      if(tips && isOut) that.hint(
-        typeof tips === 'string' ? lang.timeout.time : lang.timeout.date
-      );
+      // 是否异常提示
+      if (tips && isOut) {
+        that.hint(lang.timeout);
+      }
     }
   };
 
@@ -2444,7 +2389,7 @@
               : that.startDate && that.endDate && that.newDate(lay.extend({},that.startDate, that.startTime || {})) > that.newDate(lay.extend({},that.endDate, that.endTime || {}));
 
             return isTimeout
-              ? that.hint(options.type === 'time' ? lang.timeout.time : lang.timeout.date)
+              ? that.hint(options.type === 'time' ? lang.timeout.replace(/日期/g, '时间') : lang.timeout)
               : that.hint(lang.invalidDate);
           }
         } else {
@@ -2809,8 +2754,8 @@
 
   //加载方式
   isLayui ? (
-    laydate.ready()
-    ,layui.define('lay', function(exports){ //layui 加载
+    laydate.ready(),
+    layui.define(['lay', 'i18n'], function(exports){ // layui 加载
       laydate.path = layui.cache.dir;
       ready.run(lay);
       exports(MOD_NAME, laydate);

--- a/src/modules/layer.js
+++ b/src/modules/layer.js
@@ -9,6 +9,7 @@
 var isLayui = window.layui && layui.define;
 var $;
 var win;
+var i18n = {};
 var OBJECT_REPLACE_REGEX = /\{(\w+)\}/g;
 
 var ready = {
@@ -126,9 +127,9 @@ var ready = {
 
   /**
    * 获取对象中的值，lodash _.get 简易版
-   * @param {Record<string, any>} obj 
-   * @param {string} path 
-   * @param {any} defaultValue 
+   * @param {Record<string, any>} obj
+   * @param {string} path
+   * @param {any} defaultValue
    */
 var get = function (obj, path, defaultValue) {
   // 'a[0].b.c' ==> ['a', '0', 'b', 'c']
@@ -146,22 +147,19 @@ var get = function (obj, path, defaultValue) {
 }
 
 // 根据给定的键从国际化消息中获取翻译后的内容
-var $t = isLayui
-  ? layui.$t.bind(layui)
-  : function(key){
-    // 非 layui 环境去除命名空间前缀，从 config.lang 中取值
-    // TODO 简化版，暂不文档化，不支持配置多个 locale
-    key = key.replace(/^layer\./, '');
-    var result = get(ready.config.lang, key, key);
-    if(typeof result === 'string' && arguments.length > 1) {
-      var opts = arguments[1];
-      return result.replace(OBJECT_REPLACE_REGEX, function(match, key) {
-        return opts[key] !== undefined ? opts[key] : match;
-      })
-    }
-    return result;
-  };
-
+i18n.$t = function(key) {
+  // 非 layui 环境去除命名空间前缀，从 config.lang 中取值
+  // TODO 简化版，暂不文档化，不支持配置多个 locale
+  key = key.replace(/^layer\./, '');
+  var result = get(ready.config.lang, key, key);
+  if(typeof result === 'string' && arguments.length > 1) {
+    var opts = arguments[1];
+    return result.replace(OBJECT_REPLACE_REGEX, function(match, key) {
+      return opts[key] !== undefined ? opts[key] : match;
+    })
+  }
+  return result;
+};
 
 
 // 默认内置方法。
@@ -227,7 +225,7 @@ var layer = {
     }
     return layer.open($.extend({
       content: content,
-      btn: [$t('layer.confirm'), $t('layer.cancel')],
+      btn: [i18n.$t('layer.confirm'), i18n.$t('layer.cancel')],
       yes: yes,
       btn2: cancel
     }, type ? {} : options));
@@ -291,7 +289,7 @@ var Class = function(setings){
     that.creat();
   };
   // TODO 临时的同步方案
-  ready.config.title = $t('layer.defaultTitle');
+  ready.config.title = i18n.$t('layer.defaultTitle');
   that.index = ++layer.index;
   that.config.maxWidth = $(win).width() - 15*2; // 初始最大宽度：当前屏幕宽，左右留 15px 边距
   that.config = $.extend({}, that.config, ready.config, setings);
@@ -335,7 +333,7 @@ Class.pt.config = {
   shade: 0.3,
   fixed: true,
   move: doms[1],
-  title: $t('layer.defaultTitle'),
+  title: i18n.$t('layer.defaultTitle'),
   offset: 'auto',
   area: 'auto',
   closeBtn: 1,
@@ -523,7 +521,7 @@ Class.pt.creat = function(){
 
   switch(config.type){
     case 0:
-      config.btn = ('btn' in config) ? config.btn : $t('layer.confirm');
+      config.btn = ('btn' in config) ? config.btn : i18n.$t('layer.confirm');
       layer.closeAll('dialog');
     break;
     case 2:
@@ -1511,7 +1509,7 @@ layer.prompt = function(options, yes){
 
   return layer.open($.extend({
     type: 1,
-    btn: [$t('layer.confirm'),$t('layer.cancel')],
+    btn: [i18n.$t('layer.confirm'),i18n.$t('layer.cancel')],
     content: content,
     skin: 'layui-layer-prompt' + skin('prompt'),
     maxWidth: win.width(),
@@ -1524,7 +1522,7 @@ layer.prompt = function(options, yes){
     yes: function(index){
       var value = prompt.val();
       if(value.length > (options.maxlength||500)) {
-        layer.tips($t('layer.prompt.InputLengthPrompt', {length: (options.maxlength || 500)}), prompt, {tips: 1});
+        layer.tips(i18n.$t('layer.prompt.InputLengthPrompt', {length: (options.maxlength || 500)}), prompt, {tips: 1});
       } else {
         yes && yes(value, index, prompt);
       }
@@ -1638,7 +1636,7 @@ layer.photos = function(options, loop, key){
     // 不直接弹出
     if (!loop) return;
   } else if (data.length === 0){
-    return layer.msg($t('layer.photos.noData'));
+    return layer.msg(i18n.$t('layer.photos.noData'));
   }
 
   // 上一张
@@ -1886,12 +1884,12 @@ layer.photos = function(options, loop, key){
           if (options.toolbar) {
             arr.push([
               '<div class="layui-layer-photos-toolbar layui-layer-photos-header">',
-                '<span toolbar-event="rotate" data-option="90" title="'+ $t('layer.photos.tools.rotate') +'"><i class="layui-icon layui-icon-refresh"></i></span>',
-                '<span toolbar-event="scalex" title="'+ $t('layer.photos.tools.scaleX') +'"><i class="layui-icon layui-icon-slider"></i></span>',
-                '<span toolbar-event="zoom" data-option="0.1" title="'+ $t('layer.photos.tools.zoomIn') +'"><i class="layui-icon layui-icon-add-circle"></i></span>',
-                '<span toolbar-event="zoom" data-option="-0.1" title="'+ $t('layer.photos.tools.zoomOut') +'"><i class="layui-icon layui-icon-reduce-circle"></i></span>',
-                '<span toolbar-event="reset" title="'+ $t('layer.photos.tools.reset') +'"><i class="layui-icon layui-icon-refresh-1"></i></span>',
-                '<span toolbar-event="close" title="'+ $t('layer.photos.tools.close') +'"><i class="layui-icon layui-icon-close"></i></span>',
+                '<span toolbar-event="rotate" data-option="90" title="'+ i18n.$t('layer.photos.tools.rotate') +'"><i class="layui-icon layui-icon-refresh"></i></span>',
+                '<span toolbar-event="scalex" title="'+ i18n.$t('layer.photos.tools.scaleX') +'"><i class="layui-icon layui-icon-slider"></i></span>',
+                '<span toolbar-event="zoom" data-option="0.1" title="'+ i18n.$t('layer.photos.tools.zoomIn') +'"><i class="layui-icon layui-icon-add-circle"></i></span>',
+                '<span toolbar-event="zoom" data-option="-0.1" title="'+ i18n.$t('layer.photos.tools.zoomOut') +'"><i class="layui-icon layui-icon-reduce-circle"></i></span>',
+                '<span toolbar-event="reset" title="'+ i18n.$t('layer.photos.tools.reset') +'"><i class="layui-icon layui-icon-refresh-1"></i></span>',
+                '<span toolbar-event="close" title="'+ i18n.$t('layer.photos.tools.close') +'"><i class="layui-icon layui-icon-close"></i></span>',
               '</div>'
             ].join(''));
           }
@@ -1901,7 +1899,7 @@ layer.photos = function(options, loop, key){
             arr.push(['<div class="layui-layer-photos-toolbar layui-layer-photos-footer">',
               '<h3>'+ alt +'</h3>',
               '<em>'+ dict.imgIndex +' / '+ data.length +'</em>',
-              '<a href="'+ data[start].src + '" target="_blank">'+ $t('layer.photos.viewPicture') +'</a>',
+              '<a href="'+ data[start].src + '" target="_blank">'+ i18n.$t('layer.photos.viewPicture') +'</a>',
             '</div>'].join(''));
           }
 
@@ -1923,9 +1921,9 @@ layer.photos = function(options, loop, key){
     }, options));
   }, function(){
     layer.close(dict.loadi);
-    layer.msg($t('layer.photos.urlError.prompt'), {
+    layer.msg(i18n.$t('layer.photos.urlError.prompt'), {
       time: 30000,
-      btn: [$t('layer.photos.urlError.confirm'), $t('layer.photos.urlError.cancel')],
+      btn: [i18n.$t('layer.photos.urlError.confirm'), i18n.$t('layer.photos.urlError.cancel')],
       yes: function(){
         data.length > 1 && dict.imgnext(true,true);
       }
@@ -1964,7 +1962,8 @@ ready.run = function(_$){
 // 加载方式
 window.layui && layui.define ? (
   layer.ready(),
-  layui.define(['jquery','lay'], function(exports){ // layui
+  layui.define(['jquery', 'lay', 'i18n'], function(exports) { // layui
+    i18n.$t = layui.i18n.$t;
     layer.path = layui.cache.dir;
     ready.run(layui.$);
 

--- a/src/modules/laypage.js
+++ b/src/modules/laypage.js
@@ -2,8 +2,10 @@
  * laypage 分页组件
  */
 
-layui.define(function(exports) {
+layui.define('i18n', function(exports) {
   "use strict";
+
+  var i18n = layui.i18n;
 
   var doc = document;
   var id = 'getElementById';
@@ -72,8 +74,8 @@ layui.define(function(exports) {
       groups = config.pages;
     }
 
-    config.prev = 'prev' in config ? config.prev : layui.$t('laypage.prev'); // 上一页文本
-    config.next = 'next' in config ? config.next : layui.$t('laypage.next'); // 下一页文本
+    config.prev = 'prev' in config ? config.prev : i18n.$t('laypage.prev'); // 上一页文本
+    config.next = 'next' in config ? config.next : i18n.$t('laypage.next'); // 下一页文本
 
     // 计算当前组
     var index = config.pages > groups
@@ -100,7 +102,7 @@ layui.define(function(exports) {
 
         // 首页
         if(index > 1 && config.first !== false && groups !== 0){
-          pager.push('<a class="layui-laypage-first" data-page="1"  title="' + layui.$t('laypage.first') + '">' + (config.first || 1) +'</a>');
+          pager.push('<a class="layui-laypage-first" data-page="1"  title="' + i18n.$t('laypage.first') + '">' + (config.first || 1) +'</a>');
         }
 
         // 计算当前页码组的起始页
@@ -137,7 +139,7 @@ layui.define(function(exports) {
             pager.push('<span class="layui-laypage-spr">...</span>');
           }
           if(groups !== 0){
-            pager.push('<a class="layui-laypage-last" title="' + layui.$t('laypage.last') + '"  data-page="'+ config.pages +'">'+ (config.last || config.pages) +'</a>');
+            pager.push('<a class="layui-laypage-last" title="' + i18n.$t('laypage.last') + '"  data-page="'+ config.pages +'">'+ (config.last || config.pages) +'</a>');
           }
         }
 
@@ -153,9 +155,9 @@ layui.define(function(exports) {
 
       // 数据总数
       count: function(){
-        var countText = typeof config.countText === 'object' 
-          ? countText[0] + config.count + countText[1] 
-          : layui.$t('laypage.total', {total: config.count});
+        var countText = typeof config.countText === 'object'
+          ? countText[0] + config.count + countText[1]
+          : i18n.$t('laypage.total', {total: config.count});
 
         return '<span class="layui-laypage-count">'+ countText +'</span>'
       }(),
@@ -164,7 +166,7 @@ layui.define(function(exports) {
       limit: function(){
         var elemArr = ['<span class="layui-laypage-limits"><select lay-ignore>'];
         var template = function(item) {
-          var def = item + ' ' + layui.$t('laypage.pagesize');
+          var def = item + ' ' + i18n.$t('laypage.pagesize');
           return typeof config.limitTemplet === 'function'
             ? (config.limitTemplet(item) || def)
           : def;
@@ -192,9 +194,9 @@ layui.define(function(exports) {
       // 跳页区域
       skip: function(){
         var skipText = typeof config.skipText === 'object' ? config.skipText : [
-          layui.$t('laypage.goto'),
-          layui.$t('laypage.page'),
-          layui.$t('laypage.confirm')
+          i18n.$t('laypage.goto'),
+          i18n.$t('laypage.page'),
+          i18n.$t('laypage.confirm')
         ];
         return [
           '<span class="layui-laypage-skip">'+ skipText[0],

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -3,7 +3,7 @@
  * 表格组件
  */
 
-layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
+layui.define(['lay', 'i18n', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
   "use strict";
 
   var $ = layui.$;
@@ -15,6 +15,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
   var util = layui.util;
   var hint = layui.hint();
   var device = layui.device();
+  var i18n = layui.i18n;
 
   // api
   var table = {
@@ -192,7 +193,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
               ,'{{# } else { }}'
                 ,'<span>{{-item2.title||""}}</span>'
                 ,'{{# if(isSort){ }}'
-                  ,'<span class="layui-table-sort layui-inline"><i class="layui-edge layui-table-sort-asc" title="' + layui.$t('table.sort.asc') + '"></i><i class="layui-edge layui-table-sort-desc" title="' + layui.$t('table.sort.desc') + '"></i></span>'
+                  ,'<span class="layui-table-sort layui-inline"><i class="layui-edge layui-table-sort-asc" title="' + i18n.$t('table.sort.asc') + '"></i><i class="layui-edge layui-table-sort-desc" title="' + i18n.$t('table.sort.desc') + '"></i></span>'
                 ,'{{# } }}'
               ,'{{# } }}'
             ,'</div>'
@@ -302,7 +303,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
     defaultContextmenu: true, // 显示默认上下文菜单
     autoSort: true, // 是否前端自动排序。如果否，则需自主排序（通常为服务端处理好排序）
     text: {
-      none: layui.$t('table.noData')
+      none: '无数据'
     },
     cols: []
   };
@@ -323,7 +324,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
     thisTable.that[id] = that; // 记录当前实例对象
     thisTable.config[id] = options; // 记录当前实例配置项
 
-    //请求参数的自定义格式
+    // 请求参数的自定义格式
     options.request = $.extend({
       pageName: 'page',
       limitName: 'limit'
@@ -339,7 +340,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
       countName: 'count'
     }, options.response);
 
-    //如果 page 传入 laypage 对象
+    // 如果 page 传入 laypage 对象
     if(options.page !== null && typeof options.page === 'object'){
       options.limit = options.page.limit || options.limit;
       options.limits = options.page.limits || options.limits;
@@ -348,7 +349,12 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
       delete options.page.jump;
     }
 
-    if(!options.elem[0]) return that;
+    // 加载 i18n 自定义文本
+    options.text = $.extend(true, {
+      none: i18n.$t('table.noData')
+    }, options.text);
+
+    if (!options.elem[0]) return that;
 
     // 若元素未设 lay-filter 属性，则取实例 id 值
     if(!options.elem.attr('lay-filter')){
@@ -650,7 +656,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
     // 头部工具栏右上角默认工具
     var defaultConfig = {
       filter: {
-        title: layui.$t('table.tools.filter.title'),
+        title: i18n.$t('table.tools.filter.title'),
         layEvent: 'LAYTABLE_COLS',
         icon: 'layui-icon-cols',
         onClick: function(obj) {
@@ -703,7 +709,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
         }
       },
       exports: {
-        title: layui.$t('table.tools.export.title'),
+        title: i18n.$t('table.tools.export.title'),
         layEvent: 'LAYTABLE_EXPORT',
         icon: 'layui-icon-export',
         onClick: function(obj) { // 自带导出
@@ -712,16 +718,16 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
           var openPanel = obj.openPanel;
           var elem = obj.elem;
 
-          if (!data.length) return layer.tips(layui.$t('table.tools.export.noDataPrompt'), elem, {tips: 3});
+          if (!data.length) return layer.tips(i18n.$t('table.tools.export.noDataPrompt'), elem, {tips: 3});
           if(device.ie){
-            layer.tips(layui.$t('table.tools.export.compatPrompt'), elem, {
+            layer.tips(i18n.$t('table.tools.export.compatPrompt'), elem, {
               tips: 3
             });
           } else {
             openPanel({
               list: function(){
                 return [
-                  '<li data-type="csv">'+ layui.$t('table.tools.export.csvText') +'</li>'
+                  '<li data-type="csv">'+ i18n.$t('table.tools.export.csvText') +'</li>'
                 ].join('')
               }(),
               done: function(panel, list){
@@ -735,7 +741,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
         }
       },
       print: {
-        title: layui.$t('table.tools.print.title'),
+        title: i18n.$t('table.tools.print.title'),
         layEvent: 'LAYTABLE_PRINT',
         icon: 'layui-icon-print',
         onClick: function(obj) {
@@ -743,7 +749,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
           var options = obj.config;
           var elem = obj.elem;
 
-          if (!data.length) return layer.tips(layui.$t('table.tools.print.noDataPrompt'), elem, {tips: 3});
+          if (!data.length) return layer.tips(i18n.$t('table.tools.print.noDataPrompt'), elem, {tips: 3});
           var printWin = window.open('about:blank', '_blank');
           var style = ['<style>',
             'body{font-size: 12px; color: #5F5F5F;}',
@@ -1219,8 +1225,8 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
           if(res[response.statusName] != response.statusCode){
             that.errorView(
               res[response.msgName] ||
-              layui.$t('table.dataFormatError', {
-                statusName: response.statusName, 
+              i18n.$t('table.dataFormatError', {
+                statusName: response.statusName,
                 statusCode: response.statusCode
               })
             );
@@ -1249,7 +1255,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports) {
             that._xhrAbort = false;
             return;
           }
-          that.errorView(layui.$t('table.xhrError', {msg: msg}));
+          that.errorView(i18n.$t('table.xhrError', {msg: msg}));
           typeof options.error === 'function' && options.error(e, msg);
         }
       });

--- a/src/modules/transfer.js
+++ b/src/modules/transfer.js
@@ -2,12 +2,13 @@
  * transfer 穿梭框组件
  */
 
-layui.define(['laytpl', 'form'], function(exports) {
+layui.define(['i18n', 'laytpl', 'form'], function(exports) {
   "use strict";
 
   var $ = layui.$;
   var laytpl = layui.laytpl;
   var form = layui.form;
+  var i18n = layui.i18n;
 
   // 模块名
   var MOD_NAME = 'transfer';
@@ -71,7 +72,7 @@ layui.define(['laytpl', 'form'], function(exports) {
   var ELEM_DATA = 'layui-transfer-data';
 
   // 穿梭框模板
-  var TPL_BOX = function(obj){
+  var TPL_BOX = function(obj) {
     obj = obj || {};
     return ['<div class="layui-transfer-box" data-index="'+ obj.index +'">',
       '<div class="layui-transfer-header">',
@@ -80,54 +81,35 @@ layui.define(['laytpl', 'form'], function(exports) {
       '{{# if(d.data.showSearch){ }}',
       '<div class="layui-transfer-search">',
         '<i class="layui-icon layui-icon-search"></i>',
-        '<input type="text" class="layui-input" placeholder="'+ layui.$t('transfer.searchPlaceholder') +'">',
+        '<input type="text" class="layui-input" placeholder="'+ i18n.$t('transfer.searchPlaceholder') +'">',
       '</div>',
       '{{# } }}',
       '<ul class="layui-transfer-data"></ul>',
     '</div>'].join('');
   };
 
-  // 主模板
-  var TPL_MAIN = ['<div class="layui-transfer layui-form layui-border-box" lay-filter="LAY-transfer-{{= d.index }}">',
-    TPL_BOX({
-      index: 0,
-      checkAllName: 'layTransferLeftCheckAll'
-    }),
-    '<div class="layui-transfer-active">',
-      '<button type="button" class="layui-btn layui-btn-sm layui-btn-primary layui-btn-disabled" data-index="0">',
-        '<i class="layui-icon layui-icon-next"></i>',
-      '</button>',
-      '<button type="button" class="layui-btn layui-btn-sm layui-btn-primary layui-btn-disabled" data-index="1">',
-        '<i class="layui-icon layui-icon-prev"></i>',
-      '</button>',
-    '</div>',
-    TPL_BOX({
-      index: 1,
-      checkAllName: 'layTransferRightCheckAll'
-    }),
-  '</div>'].join('');
-
   // 构造器
-  var Class = function(options){
+  var Class = function(options) {
     var that = this;
     that.index = ++transfer.index;
-    that.config = $.extend({}, that.config, transfer.config, options);
+    that.config = $.extend({
+      title: i18n.$t('transfer.title'),
+      text: {
+        none: i18n.$t('transfer.noData'),
+        searchNone: i18n.$t('transfer.noMatch')
+      }
+    }, that.config, transfer.config, options);
     that.render();
   };
 
   // 默认配置
   Class.prototype.config = {
-    title: layui.$t('transfer.title'),
     width: 200,
     height: 360,
     data: [], // 数据源
     value: [], // 选中的数据
     showSearch: false, // 是否开启搜索
     id: '', // 唯一索引，默认自增 index
-    text: {
-      none: layui.$t('transfer.noData'),
-      searchNone: layui.$t('transfer.noMatch')
-    }
   };
 
   // 重载实例
@@ -141,6 +123,26 @@ layui.define(['laytpl', 'form'], function(exports) {
   Class.prototype.render = function(){
     var that = this;
     var options = that.config;
+
+    // 主模板
+    var TPL_MAIN = ['<div class="layui-transfer layui-form layui-border-box" lay-filter="LAY-transfer-{{= d.index }}">',
+      TPL_BOX({
+        index: 0,
+        checkAllName: 'layTransferLeftCheckAll'
+      }),
+      '<div class="layui-transfer-active">',
+        '<button type="button" class="layui-btn layui-btn-sm layui-btn-primary layui-btn-disabled" data-index="0">',
+          '<i class="layui-icon layui-icon-next"></i>',
+        '</button>',
+        '<button type="button" class="layui-btn layui-btn-sm layui-btn-primary layui-btn-disabled" data-index="1">',
+          '<i class="layui-icon layui-icon-prev"></i>',
+        '</button>',
+      '</div>',
+      TPL_BOX({
+        index: 1,
+        checkAllName: 'layTransferRightCheckAll'
+      }),
+    '</div>'].join('');
 
     // 解析模板
     var thisElem = that.elem = $(laytpl(TPL_MAIN, {

--- a/src/modules/tree.js
+++ b/src/modules/tree.js
@@ -2,13 +2,14 @@
  * tree 树组件
  */
 
-layui.define(['form','util'], function(exports) {
+layui.define(['i18n', 'form', 'util'], function(exports) {
   "use strict";
 
   var $ = layui.$;
   var form = layui.form;
   var layer = layui.layer;
   var util = layui.util;
+  var i18n = layui.i18n;
 
   // 模块名
   var MOD_NAME = 'tree';
@@ -92,7 +93,12 @@ layui.define(['form','util'], function(exports) {
   var Class = function(options){
     var that = this;
     that.index = ++tree.index;
-    that.config = $.extend({}, that.config, tree.config, options);
+    that.config = $.extend({
+      text: {
+        defaultNodeName: i18n.$t('tree.defaultNodeName'), // 节点默认名称
+        none: i18n.$t('tree.noData')  // 数据为空时的文本提示
+      }
+    }, that.config, tree.config, options);
     that.render();
   };
 
@@ -106,11 +112,6 @@ layui.define(['form','util'], function(exports) {
     onlyIconControl: false,  // 是否仅允许节点左侧图标控制展开收缩
     isJump: false,  // 是否允许点击节点时弹出新窗口跳转
     edit: false,  // 是否开启节点的操作图标
-
-    text: {
-      defaultNodeName: layui.$t('tree.defaultNodeName'), // 节点默认名称
-      none: layui.$t('tree.noData')  // 数据为空时的文本提示
-    }
   };
 
   // 重载实例
@@ -577,7 +578,7 @@ layui.define(['form','util'], function(exports) {
       // 删除
       } else {
         // 兼容性，手动替换括号为 html
-        var i18nText = layui.$t('tree.deleteNodePrompt', {
+        var i18nText = i18n.$t('tree.deleteNodePrompt', {
           name: item[customName.title] || ''
         });
         layer.confirm(i18nText, function(index){

--- a/src/modules/upload.js
+++ b/src/modules/upload.js
@@ -3,13 +3,14 @@
  * 上传组件
  */
 
-layui.define(['lay', 'layer'], function(exports) {
+layui.define(['lay', 'i18n', 'layer'], function(exports) {
   "use strict";
 
   var $ = layui.$;
   var lay = layui.lay;
   var layer = layui.layer;
   var device = layui.device();
+  var i18n = layui.i18n;
 
   // 模块名
   var MOD_NAME = 'upload';
@@ -524,11 +525,11 @@ layui.define(['lay', 'layer'], function(exports) {
 
     // 文件类型名称
     var typeName = ({
-      file: layui.$t('upload.fileType.file'),
-      images: layui.$t('upload.fileType.image'),
-      video: layui.$t('upload.fileType.video'),
-      audio: layui.$t('upload.fileType.audio')
-    })[options.accept] || layui.$t('upload.fileType.file');
+      file: i18n.$t('upload.fileType.file'),
+      images: i18n.$t('upload.fileType.image'),
+      video: i18n.$t('upload.fileType.video'),
+      audio: i18n.$t('upload.fileType.audio')
+    })[options.accept] || i18n.$t('upload.fileType.file');
 
     // 校验文件格式
     value = value.length === 0
@@ -572,7 +573,7 @@ layui.define(['lay', 'layer'], function(exports) {
 
     // 校验失败提示
     if(check){
-      that.msg(text['check-error'] || layui.$t('upload.validateMessages.fileExtensionError', {fileType: typeName}));
+      that.msg(text['check-error'] || i18n.$t('upload.validateMessages.fileExtensionError', {fileType: typeName}));
       return elemFile.value = '';
     }
 
@@ -598,9 +599,9 @@ layui.define(['lay', 'layer'], function(exports) {
       return that.msg(typeof text['limit-number'] === 'function'
         ? text['limit-number'](options, that.fileLength)
       : (
-        layui.$t('upload.validateMessages.filesOverLengthLimit', {length: options.number})
+        i18n.$t('upload.validateMessages.filesOverLengthLimit', {length: options.number})
         + '<br/>'
-        + layui.$t('upload.validateMessages.currentFilesLength', {length: that.fileLength})
+        + i18n.$t('upload.validateMessages.currentFilesLength', {length: that.fileLength})
       ));
     }
 
@@ -619,7 +620,7 @@ layui.define(['lay', 'layer'], function(exports) {
       if(limitSize) return that.msg(
         typeof text['limit-size'] === 'function'
           ? text['limit-size'](options, limitSize)
-          : layui.$t('upload.validateMessages.fileOverSizeLimit', {size: limitSize}));
+          : i18n.$t('upload.validateMessages.fileOverSizeLimit', {size: limitSize}));
     }
 
     send();
@@ -644,7 +645,7 @@ layui.define(['lay', 'layer'], function(exports) {
       var elemFile = that.elemFile;
       var item = options.item ? options.item : options.elem;
       var value = files.length > 1
-        ? layui.$t('upload.chooseText', {length: files.length})
+        ? i18n.$t('upload.chooseText', {length: files.length})
       : ((files[0] || {}).name || (elemFile[0].value.match(/[^\/\\]+\..+/g)||[]) || '');
 
       if(elemFile.next().hasClass(ELEM_CHOOSE)){

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -2,11 +2,12 @@
  * util 工具组件
  */
 
-layui.define('jquery', function(exports) {
+layui.define(['i18n', 'jquery'], function(exports) {
   "use strict";
 
   var $ = layui.$;
   var hint = layui.hint();
+  var i18n = layui.i18n;
 
   // 外部接口
   var util = {
@@ -230,15 +231,15 @@ layui.define('jquery', function(exports) {
 
       // 30 天以内，返回「多久前」
       if(stamp >= 1000*60*60*24){
-        return layui.$t('util.timeAgo.days', {days: (stamp/1000/60/60/24)|0});
+        return i18n.$t('util.timeAgo.days', {days: (stamp/1000/60/60/24)|0});
       } else if(stamp >= 1000*60*60){
-        return layui.$t('util.timeAgo.hours', {hours: (stamp/1000/60/60)|0});
+        return i18n.$t('util.timeAgo.hours', {hours: (stamp/1000/60/60)|0});
       } else if(stamp >= 1000*60*3){ // 3 分钟以内为：刚刚
-        return layui.$t('util.timeAgo.minutes', {minutes: (stamp/1000/60)|0});
+        return i18n.$t('util.timeAgo.minutes', {minutes: (stamp/1000/60)|0});
       } else if(stamp < 0){
-        return layui.$t('util.timeAgo.future');
+        return i18n.$t('util.timeAgo.future');
       } else {
-        return layui.$t('util.timeAgo.justNow');
+        return i18n.$t('util.timeAgo.justNow');
       }
     },
 
@@ -318,7 +319,7 @@ layui.define('jquery', function(exports) {
           return '晚上';
       };
 
-      var meridiem = (options && options.customMeridiem) || layui.$t('util.toDateString.meridiem') || defaultMeridiem;
+      var meridiem = (options && options.customMeridiem) || i18n.$t('util.toDateString.meridiem') || defaultMeridiem;
 
       var matches = {
         yy: function(){return String(years).slice(-2);},


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 新增 i18n 模块，代码由 layui.js 迁移至 i18n.js，用于集中处理国际化支持
- 新增 `i18n.set()` 方法，用于国际化语言配置
- 新增 i18n.html 示例，并增加「英语」、「法语」、「繁体中文」的完整切换示例
- 优化 i18n 配置的调用时机，确保当前 Layui 组件既有的提示信息都能正确读取到 i18n 配置。如果后续新增的提示信息无法确保在用户配置 i18n 后调用，那么可通过在全局对象 LAYUI_GLOBAL 预设 i18n 的方式解决（多数情况可能用不到）。
- 回滚 laydate 的 i18n 方案，考虑到该组件的复杂性以及边缘影响，laydate 仍然只支持「简体中文」和「英文」之间的切换，如果 i18n 设置的不是 `zh-CN`，则统一切换到「英文」
- 改进 i18n 的结构细节，简体中文由 `zh-cn` → `zh-CN`。

[演示]：由于 stackblitz 加载太慢，可在本地直接打开 i18n.html 测试


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
